### PR TITLE
Took out map and compass from uncommon loot.

### DIFF
--- a/config/Wasteland/CityLoot.cfg
+++ b/config/Wasteland/CityLoot.cfg
@@ -80,8 +80,6 @@
         minecraft:bucket,1,1
         minecraft:bread,4,2
         minecraft:iron_ingot,2,1
-        minecraft:compass,1,1
-        minecraft:map,1,1
         minecraft:egg,2,1
         enviromine:coldWaterBottle,3,1
      >


### PR DESCRIPTION
The map and compass were taken out from uncommon chest loot because of uselessness.